### PR TITLE
Initial socket boilerplate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5m
 github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/services/sockets/connected_clients.go
+++ b/internal/services/sockets/connected_clients.go
@@ -34,7 +34,7 @@ func (c *ConnectedClients) DeleteClient(id string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if _, exists := c.conns[id]; exists {
-		c.conns[id].Close()
-		delete(c.conns, id)
+		defer delete(c.conns, id)
+		defer c.conns[id].Close()
 	}
 }

--- a/internal/services/sockets/connected_clients.go
+++ b/internal/services/sockets/connected_clients.go
@@ -1,0 +1,40 @@
+package sockets
+
+import (
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type ConnectedClients struct {
+	lock  sync.Mutex
+	conns map[string]*websocket.Conn
+}
+
+func NewConnectedClients() *ConnectedClients {
+	return &ConnectedClients{
+		conns: make(map[string]*websocket.Conn),
+	}
+}
+
+func (c *ConnectedClients) AddClient(id string, conn *websocket.Conn) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.conns[id] = conn
+}
+
+func (c *ConnectedClients) GetClient(id string) (*websocket.Conn, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	conn, exists := c.conns[id]
+	return conn, exists
+}
+
+func (c *ConnectedClients) DeleteClient(id string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if _, exists := c.conns[id]; exists {
+		c.conns[id].Close()
+		delete(c.conns, id)
+	}
+}

--- a/internal/services/sockets/handle_socket.go
+++ b/internal/services/sockets/handle_socket.go
@@ -9,33 +9,18 @@ import (
 )
 
 // Globals
-var clients = make(map[*websocket.Conn]bool)
+var connectedClients = NewConnectedClients()
 var streamChan = make(chan []byte, 100)
-var lock sync.Mutex
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		return true //Allows all origins for now
 	},
 }
 
-// HandleSocket will accept websocket connections on '/ws'
+// HandleSocket will accept websocket connections on '/ws/{clientID}'
 func HandleSocket(mux *http.ServeMux) {
-	//Streams data to all connected clients
-	//TODO: Make it possible to only broadcast to specific groups of users.
-	go func() {
-		for data := range streamChan {
-			for conn := range clients {
-				err := conn.WriteMessage(websocket.TextMessage, data)
-				if err != nil {
-					slog.Error("Error sending to client", "reason", err)
-					lock.Lock()
-					delete(clients, conn)
-					lock.Unlock()
-				}
-			}
-		}
-	}()
-	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /ws/{clientID}", func(w http.ResponseWriter, r *http.Request) {
+		clientID := r.PathValue("clientID")
 		var wg sync.WaitGroup
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
@@ -43,21 +28,34 @@ func HandleSocket(mux *http.ServeMux) {
 			http.Error(w, "Failed to upgrade connection", http.StatusInternalServerError)
 			return
 		}
-		defer conn.Close()
-		lock.Lock()
-		clients[conn] = true
-		lock.Unlock()
+
+		if _, exists := connectedClients.GetClient(clientID); exists {
+			slog.Error("Client already connected", "reason", err)
+			return
+		}
+		connectedClients.AddClient(clientID, conn)
+		defer connectedClients.DeleteClient(clientID)
+
 		wg.Add(1)
 		//Remove client when they disconnect
 		go func() {
 			for {
-				_, _, err := conn.ReadMessage()
+				_, _, err := connectedClients.conns[clientID].ReadMessage()
 				if err != nil {
-					lock.Lock()
-					delete(clients, conn)
-					lock.Unlock()
+					connectedClients.DeleteClient(clientID)
 					wg.Done()
 					break
+				}
+			}
+		}()
+		//Send messages to connected client
+		go func() {
+			for {
+				if conn, exists := connectedClients.GetClient(clientID); exists {
+					err := conn.WriteMessage(websocket.TextMessage, <-streamChan)
+					if err != nil {
+						slog.Error("Error sending to client", "reason", err)
+					}
 				}
 			}
 		}()

--- a/internal/services/sockets/handle_socket.go
+++ b/internal/services/sockets/handle_socket.go
@@ -1,0 +1,66 @@
+package sockets
+
+import (
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+// Globals
+var clients = make(map[*websocket.Conn]bool)
+var streamChan = make(chan []byte, 100)
+var lock sync.Mutex
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true //Allows all origins for now
+	},
+}
+
+// HandleSocket will accept websocket connections on '/ws'
+func HandleSocket(mux *http.ServeMux) {
+	//Streams data to all connected clients
+	//TODO: Make it possible to only broadcast to specific groups of users.
+	go func() {
+		for data := range streamChan {
+			for conn := range clients {
+				err := conn.WriteMessage(websocket.TextMessage, data)
+				if err != nil {
+					slog.Error("Error sending to client", "reason", err)
+					lock.Lock()
+					delete(clients, conn)
+					lock.Unlock()
+				}
+			}
+		}
+	}()
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		var wg sync.WaitGroup
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			slog.Error("Failed to upgrade connection", "reason", err)
+			http.Error(w, "Failed to upgrade connection", http.StatusInternalServerError)
+			return
+		}
+		defer conn.Close()
+		lock.Lock()
+		clients[conn] = true
+		lock.Unlock()
+		wg.Add(1)
+		//Remove client when they disconnect
+		go func() {
+			for {
+				_, _, err := conn.ReadMessage()
+				if err != nil {
+					lock.Lock()
+					delete(clients, conn)
+					lock.Unlock()
+					wg.Done()
+					break
+				}
+			}
+		}()
+		wg.Wait()
+	})
+}

--- a/internal/services/sockets/handle_socket.go
+++ b/internal/services/sockets/handle_socket.go
@@ -39,12 +39,14 @@ func HandleSocket(mux *http.ServeMux) {
 		wg.Add(1)
 		//Remove client when they disconnect
 		go func() {
-			for {
-				_, _, err := connectedClients.conns[clientID].ReadMessage()
-				if err != nil {
-					connectedClients.DeleteClient(clientID)
-					wg.Done()
-					break
+			if conn, exists := connectedClients.GetClient(clientID); exists {
+				for {
+					_, _, err := conn.ReadMessage()
+					if err != nil {
+						connectedClients.DeleteClient(clientID)
+						wg.Done()
+						break
+					}
 				}
 			}
 		}()

--- a/internal/services/sockets/handle_socket.go
+++ b/internal/services/sockets/handle_socket.go
@@ -62,11 +62,11 @@ func HandleSocket(mux *http.ServeMux) {
 	})
 }
 
-// Replaces the channel that was previously used. Sends a binary message to client with {clientID} and returns a ReadCloser
+// Replaces the channel that was previously used. Sends a text message to client with {clientID} and returns a ReadCloser
 // TODO: This functionality needs to be adapted into the Post function used by the traffic client interface
 func sendToClient(clientId string, r io.Reader) (io.ReadCloser, error) {
 	if conn, exists := connectedClients.GetClient(clientId); exists {
-		w, err := conn.NextWriter(websocket.BinaryMessage)
+		w, err := conn.NextWriter(websocket.TextMessage)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/sockets/service.go
+++ b/internal/services/sockets/service.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewService(cfg Config) services.Service {
-
+	mux := http.NewServeMux()
+	HandleSocket(mux)
 	srv := &http.Server{
 		Addr:    cfg.Addr,
-		Handler: nil, //TODO: set handler with socket router.
+		Handler: mux,
 	}
 	return services.NewHTTP(srv, time.Minute)
 }

--- a/internal/services/sockets/service_test.go
+++ b/internal/services/sockets/service_test.go
@@ -1,0 +1,45 @@
+package sockets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func newHandleSocketServer(t *testing.T) * httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	HandleSocket(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func converToWSURL(target string) string {
+	ws := strings.Replace(target, "http://", "ws://", 1)
+	wss := strings.Replace(ws, "https://", "wss://", 1)
+	return wss
+}
+
+func closeWS(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	closeHandler := conn.CloseHandler()
+	err := closeHandler(websocket.CloseNormalClosure, "")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+func TestHandleSocket(t *testing.T) {
+	srv := newHandleSocketServer(t)
+	baseUrl := converToWSURL(srv.URL)
+	target, err := url.JoinPath(baseUrl, "/ws/testID")
+	require.NoError(t, err)
+	conn, _, err := websocket.DefaultDialer.Dial(target, nil)
+	t.Cleanup(func() { closeWS(t, conn)})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Added basic socket handling to allow clients to connect at /ws/{clientID} endpoint and receive data from a channel. 