### PR TITLE
Jakobii/waiting reader

### DIFF
--- a/internal/services/forwards/handle_socket_post_test.go
+++ b/internal/services/forwards/handle_socket_post_test.go
@@ -18,7 +18,7 @@ import (
 // service.
 func TestHandleSocketPost(t *testing.T) {
 	loadBalancerMock := &LoadBalancerMock{
-		SendSocketFunc: func(ctx context.Context, socketID string, r io.ReadCloser) error {
+		SendSocketFunc: func(ctx context.Context, socketID string, r io.Reader) error {
 			require.Equal(t, "1", socketID)
 			require.Equal(t, "foo", mustReadStr(t, r))
 			return nil
@@ -34,7 +34,7 @@ func TestHandleSocketPost(t *testing.T) {
 
 func TestHandleSocketPost_socket_id_not_open(t *testing.T) {
 	loadBalancerMock := &LoadBalancerMock{
-		SendSocketFunc: func(ctx context.Context, socketID string, r io.ReadCloser) error {
+		SendSocketFunc: func(ctx context.Context, socketID string, r io.Reader) error {
 			return traffic.ErrNotFound
 		},
 	}

--- a/internal/services/forwards/mocks_test.go
+++ b/internal/services/forwards/mocks_test.go
@@ -10,9 +10,9 @@ import (
 // LoadBalancerMock satisfies traffic.ClientLoadBalancer interface.
 type LoadBalancerMock struct {
 	traffic.LoadBalancer
-	SendSocketFunc func(ctx context.Context, socketID string, r io.ReadCloser) error
+	SendSocketFunc func(ctx context.Context, socketID string, r io.Reader) error
 }
 
-func (c *LoadBalancerMock) SendSocket(ctx context.Context, socketID string, r io.ReadCloser) error {
+func (c *LoadBalancerMock) SendSocket(ctx context.Context, socketID string, r io.Reader) error {
 	return c.SendSocketFunc(ctx, socketID, r)
 }

--- a/internal/traffic/lb.go
+++ b/internal/traffic/lb.go
@@ -12,7 +12,7 @@ type LoadBalancer interface {
 	OpenSocket(id string) (Socket, error)
 	// SendSocket sends a reader to an open socket. If the
 	// socket is not open it returns ErrNotFound.
-	SendSocket(ctx context.Context, socketID string, r io.ReadCloser) error
+	SendSocket(ctx context.Context, socketID string, r io.Reader) error
 }
 
 // Socket is a long lived connection that is waited on to receive incoming

--- a/internal/traffic/lb_test.go
+++ b/internal/traffic/lb_test.go
@@ -49,11 +49,11 @@ func ExampleLoadBalancer_OpenSocket() {
 }
 
 type LoadBalancerMock struct {
-	SendSocketFunc func(ctx context.Context, socketID string, r io.ReadCloser) error
+	SendSocketFunc func(ctx context.Context, socketID string, r io.Reader) error
 	OpenSocketFunc func(id string) (Socket, error)
 }
 
-func (c LoadBalancerMock) SendSocket(ctx context.Context, socketID string, r io.ReadCloser) error {
+func (c LoadBalancerMock) SendSocket(ctx context.Context, socketID string, r io.Reader) error {
 	return c.SendSocketFunc(ctx, socketID, r)
 }
 

--- a/internal/traffic/reader.go
+++ b/internal/traffic/reader.go
@@ -1,0 +1,44 @@
+package traffic
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// waitingReadCloser satisfies the io.ReadCloser interface.
+type waitingReadCloser struct {
+	r        io.Reader
+	n        int
+	done     chan struct{}
+	isClosed atomic.Bool
+}
+
+func newWaitingReadCloser(r io.Reader) *waitingReadCloser {
+	return &waitingReadCloser{
+		r:    r,
+		done: make(chan struct{}, 1),
+	}
+}
+
+// Wait for Close to signal done, too allow resourse cleanup.
+func (w *waitingReadCloser) Wait() <-chan struct{} {
+	return w.done
+}
+
+func (w *waitingReadCloser) Read(p []byte) (n int, err error) {
+	if w.isClosed.Load() {
+		return w.n, io.EOF
+	}
+	w.n += len(p)
+	return w.r.Read(p)
+}
+
+// Close can safely be called mutliple times.
+func (w *waitingReadCloser) Close() error {
+	w.isClosed.Store(true)
+	select {
+	case w.done <- struct{}{}:
+	default:
+	}
+	return nil
+}

--- a/internal/traffic/reader_test.go
+++ b/internal/traffic/reader_test.go
@@ -1,0 +1,17 @@
+package traffic
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Example_waitingReadCloser() {
+	r := newWaitingReadCloser(strings.NewReader("foo"))
+	go func() {
+		defer r.Close()
+		fmt.Fscanln(r)
+	}()
+	// wait for Fscanln to finish.
+	<-r.Wait()
+	// Outputs: foo
+}


### PR DESCRIPTION
A io.ReadCloser that can wait for close.

This changes the LoadBalancer interface's SendSocket method to only require a reader.